### PR TITLE
处理Rafy ORM Sql Server 中 DateTime 类型的字段溢出的问题 #101 和无法生成实体注释到数据库 #66 (#…

### DIFF
--- a/Rafy/Rafy/DbMigration/DbMigrationContext.cs
+++ b/Rafy/Rafy/DbMigration/DbMigrationContext.cs
@@ -221,7 +221,7 @@ namespace Rafy.DbMigration
 
             var dbMeta = this.DatabaseMetaReader.Read();
 
-            var differ = new ModelDiffer();
+            var differ = new ModelDiffer((_runGenerator as SqlRunGenerator).DbTypeCoverter);
             differ.IDbIdentifierProvider = (_runGenerator as SqlRunGenerator).IdentifierQuoter;
             var changeSet = differ.Distinguish(dbMeta, destination);
 

--- a/Rafy/Rafy/DbMigration/Model/Differ/ModelDiffer.cs
+++ b/Rafy/Rafy/DbMigration/Model/Differ/ModelDiffer.cs
@@ -24,6 +24,13 @@ namespace Rafy.DbMigration.Model
     {
         internal IDbIdentifierQuoter IDbIdentifierProvider;
 
+        private DbTypeConverter dbTypeConverter;
+
+        internal ModelDiffer(DbTypeConverter dbTypeConverter)
+        {
+            this.dbTypeConverter = dbTypeConverter;
+        }
+
         /// <summary>
         /// 计算出两个数据库元数据的所有表差别
         /// </summary>
@@ -137,7 +144,7 @@ namespace Rafy.DbMigration.Model
 
                 if (newColumn.IsPrimaryKey != oldColumn.IsPrimaryKey) { columnChanged.IsPrimaryKeyChanged = true; }
 
-                if (!DbTypeConverter.IsCompatible(newColumn.DbType, oldColumn.DbType)) { columnChanged.IsDbTypeChanged = true; }
+                if (!dbTypeConverter.IsCompatible(newColumn.DbType, oldColumn.DbType)) { columnChanged.IsDbTypeChanged = true; }
 
                 //ForeignRelationChangeType
                 columnChanged.ForeignRelationChangeType = ChangeType.UnChanged;
@@ -164,7 +171,7 @@ namespace Rafy.DbMigration.Model
         {
             if (a.Table.Name.EqualsIgnoreCase(b.Table.Name) &&
                 a.Name.EqualsIgnoreCase(b.Name) &&
-                DbTypeConverter.IsCompatible(a.DbType, b.DbType) &&
+                dbTypeConverter.IsCompatible(a.DbType, b.DbType) &&
                 //a.DataType == b.DataType &&
                 a.IsRequired == b.IsRequired &&
                 a.IsForeignKey == b.IsForeignKey &&

--- a/Rafy/Rafy/DbMigration/Providers/DbTypeConverter.cs
+++ b/Rafy/Rafy/DbMigration/Providers/DbTypeConverter.cs
@@ -54,6 +54,7 @@ namespace Rafy.DbMigration
             if (clrType == typeof(long)) { return DbType.Int64; }
             if (clrType == typeof(bool)) { return DbType.Boolean; }
             if (clrType == typeof(DateTime)) { return DbType.DateTime; }
+            if (clrType == typeof(DateTimeOffset)) { return DbType.DateTimeOffset; }
             if (clrType == typeof(Guid)) { return DbType.Guid; }
             if (clrType == typeof(double)) { return DbType.Double; }
             if (clrType == typeof(byte)) { return DbType.Byte; }
@@ -146,7 +147,7 @@ namespace Rafy.DbMigration
         /// <param name="oldColumnType"></param>
         /// <param name="newColumnType"></param>
         /// <returns></returns>
-        internal static bool IsCompatible(DbType oldColumnType, DbType newColumnType)
+        internal virtual bool IsCompatible(DbType oldColumnType, DbType newColumnType)
         {
             if (oldColumnType == newColumnType) return true;
 

--- a/Rafy/Rafy/DbMigration/Providers/Oracle/OracleDbTypeConverter.cs
+++ b/Rafy/Rafy/DbMigration/Providers/Oracle/OracleDbTypeConverter.cs
@@ -120,7 +120,7 @@ namespace Rafy.DbMigration.Oracle
         /// <returns></returns>
         public override DbType FromClrType(Type clrType)
         {
-            if (clrType == typeof(DateTime)) { return DbType.Date; }
+            if (clrType == typeof(DateTime) || clrType == typeof(DateTimeOffset)) { return DbType.Date; }
 
             var value = base.FromClrType(clrType);
 
@@ -153,6 +153,10 @@ namespace Rafy.DbMigration.Oracle
                 {
                     value = TypeHelper.CoerceValue(typeof(int), value);
                 }
+                else if (value is DateTimeOffset)
+                {
+                    value = ((DateTimeOffset)value).DateTime;
+                }
             }
 
             return value;
@@ -173,6 +177,19 @@ namespace Rafy.DbMigration.Oracle
                 if (clrType == typeof(bool))
                 {
                     dbValue = dbValue.ToString() == "1" ? true : false;
+                }
+                else if (clrType == typeof(DateTimeOffset))
+                {
+                    DateTime dateTime = (DateTime)dbValue;
+
+                    if (dateTime == DateTime.MinValue)
+                    {
+                        dbValue = DateTimeOffset.MinValue;
+                    }
+                    else
+                    {
+                        dbValue = (DateTimeOffset)DateTime.SpecifyKind(dateTime, DateTimeKind.Local);
+                    }
                 }
             }
             else

--- a/Rafy/Rafy/Domain/ORM/DbMigration/CommentFinder.cs
+++ b/Rafy/Rafy/Domain/ORM/DbMigration/CommentFinder.cs
@@ -77,13 +77,21 @@ namespace Rafy.Domain.ORM.DbMigration
         //    return this.TryFindComment(type.Assembly, key);
         //}
 
+        /// <summary>
+        /// 通过程序集获取对应xml文件，为设置备注做准备
+        /// Assembly.CodeBase vs Assembly.Location
+        /// https://www.cnblogs.com/happyframework/p/3612494.html
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
         private string TryFindComment(Assembly assembly, string key)
         {
             XDocument xdoc = null;
             if (!_store.TryGetValue(assembly, out xdoc))
             {
-                var assemblyPath = assembly.Location;
-                var xmlDocPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.GetFileNameWithoutExtension(assemblyPath) + ".xml");
+                var assemblyCodeBase = assembly.CodeBase.Replace("file:///", "");
+                var xmlDocPath = Path.Combine(Path.GetDirectoryName(assemblyCodeBase), Path.GetFileNameWithoutExtension(assemblyCodeBase) + ".xml");
                 if (File.Exists(xmlDocPath))
                 {
                     try

--- a/Test/Rafy.UnitTest/Entities/Yacht.cs
+++ b/Test/Rafy.UnitTest/Entities/Yacht.cs
@@ -109,6 +109,15 @@ namespace Rafy.UnitTest
             set { this.SetProperty(DecimalValueProperty, value); }
         }
 
+        public static readonly Property<DateTimeOffset?> DateTimeOffsetValueProperty = P<Yacht>.Register(e => e.DateTimeOffsetValue);
+        /// <summary>
+        /// 
+        /// </summary>
+        public DateTimeOffset? DateTimeOffsetValue
+        {
+            get { return this.GetProperty(DateTimeOffsetValueProperty); }
+            set { this.SetProperty(DateTimeOffsetValueProperty, value); }
+        }
 
         #endregion
 

--- a/Test/RafyUnitTest/Rafy/DbMigrationTest.cs
+++ b/Test/RafyUnitTest/Rafy/DbMigrationTest.cs
@@ -36,6 +36,8 @@ namespace RafyUnitTest
     [TestClass]
     public class DbMigrationTest
     {
+        private static DbTypeConverter dbTypeConverter;
+
         [ClassInitialize]
         public static void DbMigrationTest_ClassInitialize(TestContext context)
         {
@@ -52,6 +54,9 @@ namespace RafyUnitTest
 
                 c.ResetDbVersion();
                 c.ResetHistory();
+
+                var dbProvider = DbMigrationProviderFactory.GetProvider(c.DbSetting);
+                dbTypeConverter = (dbProvider.CreateRunGenerator() as SqlRunGenerator).DbTypeCoverter;
             };
         }
 
@@ -164,7 +169,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.String));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.String));
             });
         }
 
@@ -180,7 +185,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.AnsiString));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.AnsiString));
             });
         }
 
@@ -196,7 +201,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Date));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Date));
             });
         }
 
@@ -212,7 +217,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Time));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Time));
             });
         }
 
@@ -228,7 +233,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.DateTime));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.DateTime));
             });
         }
 
@@ -244,7 +249,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.DateTimeOffset));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.DateTimeOffset));
             });
         }
 
@@ -260,7 +265,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Int32));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Int32));
             });
         }
 
@@ -276,7 +281,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Int64));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Int64));
             });
         }
 
@@ -292,7 +297,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Double));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Double));
             });
         }
 
@@ -308,7 +313,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Decimal));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Decimal));
             });
         }
 
@@ -324,7 +329,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Binary));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Binary));
             });
         }
 
@@ -340,7 +345,7 @@ namespace RafyUnitTest
                 var taskTable = result.FindTable("Task");
                 var c1 = taskTable.FindColumn("TestingColumn");
                 Assert.IsTrue(c1 != null && c1.IsRequired);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Boolean));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.Boolean));
             });
         }
 
@@ -358,7 +363,7 @@ namespace RafyUnitTest
                     var taskTable = result.FindTable("Task");
                     var c1 = taskTable.FindColumn("TestingColumn");
                     Assert.IsTrue(c1 != null && c1.IsRequired);
-                    Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.String));
+                    Assert.IsTrue(dbTypeConverter.IsCompatible(c1.DbType, DbType.String));
                 });
             }
         }
@@ -398,7 +403,7 @@ namespace RafyUnitTest
                 Assert.IsTrue(column != null);
 
                 var p = DbSetting.FindOrCreate(UnitTestEntityRepositoryDataProvider.DbSettingName).ProviderName;
-                Assert.IsTrue(DbTypeConverter.IsCompatible(column.DbType, DbType.Xml));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(column.DbType, DbType.Xml));
             });
         }
 
@@ -417,7 +422,7 @@ namespace RafyUnitTest
                 Assert.IsTrue(column != null);
 
                 var p = DbSetting.FindOrCreate(UnitTestEntityRepositoryDataProvider.DbSettingName).ProviderName;
-                Assert.IsTrue(DbTypeConverter.IsCompatible(column.DbType, DbType.Xml));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(column.DbType, DbType.Xml));
             });
         }
 
@@ -437,7 +442,7 @@ namespace RafyUnitTest
                 var table = result.FindTable("Task");
                 var column = table.FindColumn("Name");
                 Assert.IsTrue(column != null);
-                Assert.IsTrue(DbTypeConverter.IsCompatible(column.DbType, DbType.Double));
+                Assert.IsTrue(dbTypeConverter.IsCompatible(column.DbType, DbType.Double));
                 Assert.IsTrue(column.IsRequired);
             });
         }

--- a/Test/RafyUnitTest/Rafy/EntityTest.cs
+++ b/Test/RafyUnitTest/Rafy/EntityTest.cs
@@ -113,7 +113,7 @@ namespace RafyUnitTest
         [TestMethod]
         public void ET_PersistenceStatus_New_SetNewWillResetId()
         {
-            var item = new TestUser{ Id = 111 };
+            var item = new TestUser { Id = 111 };
             item.PersistenceStatus = PersistenceStatus.Unchanged;
 
             item.PersistenceStatus = PersistenceStatus.New;
@@ -599,6 +599,34 @@ namespace RafyUnitTest
 
                 var newBook2 = repo.GetById(book.Id);
                 Assert.AreEqual(newBook2.IsSoldOut, false);
+            }
+        }
+
+        /// <summary>
+        /// https://technet.microsoft.com/zh-cn/library/ms172424(v=sql.110).aspx
+        /// </summary>
+        [TestMethod]
+        public void ET_Property_DateTimeOffset()
+        {
+            using (var tran = RF.TransactionScope(UnitTestEntityRepositoryDataProvider.DbSettingName))
+            {
+                Yacht car = new Yacht()
+                {
+                    DateTimeOffsetValue = DateTime.Parse("1030-1-1")
+                };
+
+                if (tran.DbSetting.ProviderName.Contains("SqlServerCe"))
+                {
+                    car.DateTimeOffsetValue = DateTime.Parse("1753-1-1");
+                }
+
+                var repo = RF.ResolveInstance<YachtRepository>();
+                repo.Save(car);
+
+                long id = car.Id;
+                var newCar = repo.GetById(id);
+
+                Assert.AreEqual(newCar.DateTimeOffsetValue, car.DateTimeOffsetValue);
             }
         }
 

--- a/Test/RafyUnitTest/Rafy/ORMTest.cs
+++ b/Test/RafyUnitTest/Rafy/ORMTest.cs
@@ -4791,7 +4791,7 @@ FROM Book");
             var repo = RepositoryFacade.ResolveInstance<BookRepository>();
             using (RF.TransactionScope(repo))
             {
-                var book=new Book();
+                var book = new Book();
                 repo.Save(book);
                 if (!ids.Contains(book.Id))
                 {
@@ -5390,7 +5390,9 @@ ORDER BY Article.Code ASC");
                 var db = context.DatabaseMetaReader.Read();
                 var table = db.FindTable("Customer");
                 var c1 = table.FindColumn("DecimalProperty1");
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Decimal));
+                var dbProvider = DbMigrationProviderFactory.GetProvider(context.DbSetting);
+                var dbTypeCoverter = (dbProvider.CreateRunGenerator() as SqlRunGenerator).DbTypeCoverter;
+                Assert.IsTrue(dbTypeCoverter.IsCompatible(c1.DbType, DbType.Decimal));
             }
         }
 
@@ -5402,7 +5404,9 @@ ORDER BY Article.Code ASC");
                 var db = context.DatabaseMetaReader.Read();
                 var table = db.FindTable("Customer");
                 var c1 = table.FindColumn("DecimalProperty2");
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Decimal));
+                var dbProvider = DbMigrationProviderFactory.GetProvider(context.DbSetting);
+                var dbTypeCoverter = (dbProvider.CreateRunGenerator() as SqlRunGenerator).DbTypeCoverter;
+                Assert.IsTrue(dbTypeCoverter.IsCompatible(c1.DbType, DbType.Decimal));
                 //Assert.IsTrue(c1.Length == "18,4");
             }
         }
@@ -5415,7 +5419,9 @@ ORDER BY Article.Code ASC");
                 var db = context.DatabaseMetaReader.Read();
                 var table = db.FindTable("Customer");
                 var c1 = table.FindColumn("DecimalProperty3");
-                Assert.IsTrue(DbTypeConverter.IsCompatible(c1.DbType, DbType.Double));
+                var dbProvider = DbMigrationProviderFactory.GetProvider(context.DbSetting);
+                var dbTypeCoverter = (dbProvider.CreateRunGenerator() as SqlRunGenerator).DbTypeCoverter;
+                Assert.IsTrue(dbTypeCoverter.IsCompatible(c1.DbType, DbType.Double));
             }
         }
 


### PR DESCRIPTION
…133)

* 添加对DateTimeOffset类型的支持
修改DbTypeConverter.IsCompatible方法

* 规范代码

* 修改测试兼容SqlCE